### PR TITLE
Prevent overwriting existing files in directory without --force

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   "port": 5555,
   "path": "./tmp/spotlight",
   "slow": 2000,
-  "ignore": ["no-realistic-dashboard.json"]
+  "ignore": ["no-realistic-dashboard.json"],
+  "force": false
 }

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -11,30 +11,17 @@ module.exports.init = function (config) {
     var deferred = Q.defer(),
         path = require('path').resolve(__dirname, process.cwd(), config.path);
 
-    rimraf(config.path, function () {
-      console.log('Cloning Spotlight...');
-      git.Repo.clone(config.repo, config.path, null, function (error, repo) {
-        if (error) {
-          deferred.reject(error);
+    init(config).then(function () {
+      fs.readdir(config.path + config.stubDir, function (err, files) {
+        if (err) {
+          deferred.reject(err);
         } else {
-          repo.getMaster(function (error) {
-            if (error) {
-              deferred.reject(error);
-            } else {
-              fs.readdir(config.path + config.stubDir, function (err, files) {
-                if (err) {
-                  deferred.reject(err);
-                } else {
-                  files.forEach(function (file) {
-                    if (file.indexOf('.json') !== -1 && config.ignore.indexOf(file) === -1) {
-                      configs[file] = require(path + config.stubDir + file);
-                    }
-                  });
-                  deferred.resolve();
-                }
-              });
+          files.forEach(function (file) {
+            if (file.indexOf('.json') !== -1 && config.ignore.indexOf(file) === -1) {
+              configs[file] = require(path + config.stubDir + file);
             }
           });
+          deferred.resolve();
         }
       });
     });
@@ -42,6 +29,54 @@ module.exports.init = function (config) {
     return deferred.promise;
   };
 };
+
+function init(config) {
+  var deferred = Q.defer(),
+      path = require('path').resolve(__dirname, process.cwd(), config.path);
+
+  git.Repo.open(path, function (err) {
+    if (err) {
+      fs.readdir(path, function (err, files) {
+        if (err) {
+          if (err.code === 'ENOENT') {
+            clone(config, deferred);
+          } else {
+            deferred.reject(err);
+          }
+        } else if (files.length && !config.force) {
+          console.log(path + ' is not empty');
+          console.log('To overwrite, use `--force`');
+          deferred.reject();
+        } else {
+          clone(config, deferred);
+        }
+      });
+    } else {
+      if (!config.force) {
+        console.log(config.repo + ' is already checked out in ' + path);
+        console.log('To overwrite, use `--force`');
+        deferred.resolve();
+      } else {
+        clone(config, deferred);
+      }
+    }
+  });
+
+  return deferred.promise;
+}
+
+function clone(config, deferred) {
+  rimraf(config.path, function () {
+    console.log('Cloning Spotlight...');
+    git.Repo.clone(config.repo, config.path, null, function (err) {
+      if (err) {
+        deferred.reject(err);
+      } else {
+        deferred.resolve();
+      }
+    });
+  });
+}
 
 module.exports.dashboards = function () {
   return Q(_.filter(configs, function (json) {


### PR DESCRIPTION
Closes #13 

Add a `--force` flag to prevent overwriting existing files. Allows for use of cheapseats against local development spotlight.
