### PR TITLE
Fixed Q throwing error on test fails.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,5 +43,4 @@ browser.init()
   })
   .fin(function () {
     return browser.quit();
-  })
-  .done();
+  });


### PR DESCRIPTION
stops Q doing this:

```
...cheapseats/node_modules/q/q.js:126
                    throw e;
```
