### PR TITLE
Correctly resolve relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ var wd = require('wd'),
     spotlight = require('./lib/spotlight'),
     dashboardTest = require('./lib/tests/dashboard');
 
+config.path = require('path').resolve(__dirname, config.path);
+
 util._extend(config, argh.argv);
+
 
 chai.use(chaiAsPromised);
 chai.should();


### PR DESCRIPTION
Allows running cheapseats from other directories.
i.e. `node ../cheapseats/index.js`
