### PR TITLE
Don't kill webdriver before the browser has exited

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,10 +59,12 @@ driver.init(browser, config)
     exitcode = 1;
   })
   .fin(function () {
-    driver.kill();
-    server.kill();
     return browser.quit();
   })
   .then(function () {
+    driver.kill();
+    server.kill();
+  })
+  .fin(function () {
     process.exit(exitcode);
   });


### PR DESCRIPTION
Doing that causes the browser.exit to fail and stops the file executing further.
