### PR TITLE
Make nodegit a dev dependency, hidden behind a config flag

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:3057/performance/",
+  "clone": false,
   "standalone": false,
   "timeout": 30000,
   "reporter": "spec",

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -1,7 +1,6 @@
 var Q = require('q'),
     rimraf = require('rimraf'),
     fs = require('fs'),
-    git = require('nodegit'),
     _ = require('underscore');
 
 var configs = {};
@@ -34,33 +33,38 @@ function init(config) {
   var deferred = Q.defer(),
       path = require('path').resolve(__dirname, process.cwd(), config.path);
 
-  git.Repo.open(path, function (err) {
-    if (err) {
-      fs.readdir(path, function (err, files) {
-        if (err) {
-          if (err.code === 'ENOENT') {
-            clone(config, deferred);
+  if (config.clone) {
+    var git = require('nodegit');
+    git.Repo.open(path, function (err) {
+      if (err) {
+        fs.readdir(path, function (err, files) {
+          if (err) {
+            if (err.code === 'ENOENT') {
+              clone(config, deferred);
+            } else {
+              deferred.reject(err);
+            }
+          } else if (files.length && !config.force) {
+            console.log(path + ' is not empty');
+            console.log('To overwrite, use `--force`');
+            deferred.reject();
           } else {
-            deferred.reject(err);
+            clone(config, deferred);
           }
-        } else if (files.length && !config.force) {
-          console.log(path + ' is not empty');
+        });
+      } else {
+        if (!config.force) {
+          console.log(config.repo + ' is already checked out in ' + path);
           console.log('To overwrite, use `--force`');
-          deferred.reject();
+          deferred.resolve();
         } else {
           clone(config, deferred);
         }
-      });
-    } else {
-      if (!config.force) {
-        console.log(config.repo + ' is already checked out in ' + path);
-        console.log('To overwrite, use `--force`');
-        deferred.resolve();
-      } else {
-        clone(config, deferred);
       }
-    }
-  });
+    });
+  } else {
+    deferred.resolve();
+  }
 
   return deferred.promise;
 }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "chai": "1.9.1",
     "chai-as-promised": "4.1.1",
     "q": "1.0.1",
-    "nodegit": "0.1.1",
     "rimraf": "2.2.6",
     "underscore": "1.6.0",
     "debug": "0.8.0",
     "mocha": "1.18.2",
     "argh": "0.1.1",
     "ps-node": "0.0.3"
+  },
+  "devDependencies": {
+    "nodegit": "0.1.1"
   }
 }


### PR DESCRIPTION
Loading nodegit in every build is really slow, when we don't really use it in any real instance because we operate from inside a spotlight instance as a submodule.

Adding it as a dev dependency allows it to be available when running locally, but not incuded as part of the build process.
