### PR TITLE
Add option to take screenshots of each dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Common configuration options are listed below, these can be set in config.json, 
 
 * `--baseUrl` - the server to run tests against.
 * `--standalone` - cheapseats will spin up its own instance of spotlight (and phantomj, if required) to run tests against, instead of using the server provided in `--baseUrl`.
+* `--screenshots` - directory to save a screenshot of each dashboard into. A falsy value will disable screenshots.
 * `--path` - cheapseats will look here for an instance of spotlight. If it finds an empty directory, it will clone spotlight/master into this directory.
 * `--force` - will make cheapseats *always* clone spotlight into the path provided, overwriting anything in that directory. *Use with care*
 * `--port` - the port on which cheapseats will look for a webdriver compatible interface (e.g. phantomjs, selenium). By default phantomjs will run on 5555 and selenium will run on 4444. Note that standalone mode will *always* attempt to start phantomjs on the port specified if no instance is found.

--- a/lib/tests/dashboard.js
+++ b/lib/tests/dashboard.js
@@ -12,7 +12,18 @@ module.exports = function (browser, dashboard, suite, config) {
       .$('body.ready', 5000)
       // if a dashboard isn't ready after 5s then there's probably a failed module
       // run module tests to help establish which
-      .fail(function () {});
+      .fail(function () {})
+      .then(function () {
+        if (config.screenshots) {
+          return browser.screenshot(config.screenshots + '/' + dashboard.slug + '.png').fail(function (err) {
+            if (err.code === 'ENOENT') {
+              throw new Error('Screenshot directory ' + config.screenshots + ' does not exist.');
+            } else {
+              throw err;
+            }
+          });
+        }
+      });
   });
 
   var tests = {

--- a/lib/wd-helpers.js
+++ b/lib/wd-helpers.js
@@ -23,4 +23,18 @@ module.exports = function (wd, config) {
     });
   });
 
+  wd.addPromiseChainMethod('screenshot', function (file) {
+    return this.takeScreenshot().then(function (data) {
+      var promise = Q.defer();
+      require('fs').writeFile(file, data, { encoding: 'base64' }, function (err) {
+        if (err) {
+          promise.reject(err);
+        } else {
+          promise.resolve();
+        }
+      });
+      return promise.promise;
+    });
+  });
+
 };


### PR DESCRIPTION
I forgot to PR this yesterday.
- Adds a `--screenshot` option which will make a screenshot of each dashboard once it loads, in the dir specified.
- Adds a screenshot helper in WD which is useful for debugging.
