### PR TITLE
Temporarily disable student finance dashboard until data is stable

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   "port": 5555,
   "path": "./tmp/spotlight",
   "slow": 5000,
-  "ignore": ["no-realistic-dashboard.json"],
+  "ignore": ["no-realistic-dashboard.json", "student-finance.json"],
   "force": false,
   "serverConfig": {
     "port": 7070,


### PR DESCRIPTION
If we want to make the build stable until student finance data gets fixed.
