### PR TITLE
Handle trimmed data sets for testing duration output

### DIFF
--- a/lib/tests/modules/completion_rate.js
+++ b/lib/tests/modules/completion_rate.js
@@ -25,7 +25,7 @@ module.exports = function (browser, module, suite, config) {
     },
     'has period output': function () {
       var regex;
-      if (module.duration && !module['start-at']) {
+      if (module.duration && !module['start-at'] && !module.trim) {
         regex = new RegExp('last ' + module.duration + ' ' + module.period + 's');
       } else {
         regex = new RegExp('last [0-9]+ ' + module.period + 's');

--- a/lib/tests/modules/user_satisfaction_graph.js
+++ b/lib/tests/modules/user_satisfaction_graph.js
@@ -11,5 +11,7 @@ module.exports = function (browser, module, suite, config) {
     }
   ];
 
+  module.trim = module.trim === undefined ? true : module.trim;
+
   require('./completion_rate')(browser, module, suite, config);
 };


### PR DESCRIPTION
Don't expect the number to necessarily match the duration for trimmed data sets, just test for any number.
