### PR TITLE
Allow a range of dashboards to be specified, to run a subset of the full test suite

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,9 +43,20 @@ function testDashboards(config, prefix) {
   return spotlight.init(config)()
     .then(spotlight.dashboards)
     .then(function (dashboards) {
+
+      var range = (argh.argv.range || '').split('..');
+      range[0] = parseInt(range[0], 10) || 0;
+      if (range.length === 1) {
+        range[1] = range[0] + 1;
+      } else {
+        range[1] = range[1] ? parseInt(range[1], 10) : dashboards.length;
+      }
+
       var suite = Mocha.Suite.create(mocha.suite, title);
-      dashboards.forEach(function (dashboard) {
-        dashboardTest(browser, dashboard, suite, config);
+      dashboards.forEach(function (dashboard, i) {
+        if (i >= range[0] && i < range[1]) {
+          dashboardTest(browser, dashboard, suite, config);
+        }
       });
     });
 }


### PR DESCRIPTION
This is a precursor for some work splitting the travis build across multiple jobs.

You can run:
- `./cheapseats --range 0..10` to run only the first 10 dashboards.
- `./cheapseats --range 100..` to run from 100 onwards.
- `./cheapseats --range 10` to run only dashboard number 10.
