### PR TITLE
Allow use of Mocha's bail flag to stop tests at the first failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var mocha = new Mocha({
   reporter: config.reporter,
   timeout: config.timeout,
   slow: config.slow,
+  bail: config.bail,
   grep: argh.argv.grep
 });
 


### PR DESCRIPTION
The tests take a long time to run, and in development you don't necessarily want to wait for everything to finish to get the failure details.
