### PR TITLE
Allow commas in kpi numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function testDashboards(config, prefix) {
       });
     });
 }
-config.valueRegex = /^(((£)?[0-9\.]+(bn|m|k|%)?)|\(?no data\)?)$/;
+config.valueRegex = /^(((£)?[0-9\.,]+(bn|m|k|%)?)|\(?no data\)?)$/;
 
 driver.init(browser, config)
   .then(function () {


### PR DESCRIPTION
We have a change to display numbers in format 12.3k above 10,000. This means we need to allow "1,234" in numerical output.
