### PR TITLE
Remove query-params from dashboard configs

### DIFF
--- a/lib/tests/modules/list.js
+++ b/lib/tests/modules/list.js
@@ -14,7 +14,7 @@ module.exports = function (browser, module, suite /*, config*/) {
     'contains list items': function () {
       return browser
         .elementsByCssSelector('#' + module.slug + ' ol li').then(function (elems) {
-          elems.length.should.equal(module['query-params'].limit);
+          elems.length.should.equal(module.limit);
         });
     }
 


### PR DESCRIPTION
To go with https://github.com/alphagov/spotlight/pull/535
