### PR TITLE
transaction taglines

### DIFF
--- a/lib/tests/dashboards/transaction.js
+++ b/lib/tests/dashboards/transaction.js
@@ -8,9 +8,15 @@ module.exports = function (browser, dashboard, suite, config) {
   var tests = {
 
     'has a description': function () {
-      return browser
-        .$('#content header p.tagline').text()
-          .should.eventually.equal('This dashboard shows information about how the ' + dashboard.title + ' service is currently performing.');
+      if (dashboard.tagline) {
+        return browser
+          .$('#content header p.tagline').text()
+            .should.eventually.equal(dashboard.tagline);
+      } else {
+        return browser
+          .$('#content header p.tagline').text()
+            .should.eventually.equal('This dashboard shows information about how the ' + dashboard.title + ' service is currently performing.');
+      }
     },
 
     'has a breadcrumb': function () {


### PR DESCRIPTION
We don't correctly test the functionality of cheapseats here.
If the dashboard has a tagline we just render it.
If it doesn't we use the title with standard copy.
