### PR TITLE
Check for duration-type modules when checking the format of output

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ function testDashboards(config, prefix) {
     });
 }
 config.valueRegex = /^(((£)?[0-9\.,]+(bn|m|k|%)?)|\(?no data\)?)$/;
+config.durationRegex = /^(([0-9]+m )?([0-9]+s)?|\(?no data\)?)$/;
 
 driver.init(browser, config)
   .then(function () {

--- a/lib/tests/modules/single_timeseries.js
+++ b/lib/tests/modules/single_timeseries.js
@@ -16,10 +16,12 @@ module.exports = function (browser, module, suite, config) {
 
   var tests = {
     'has a numerical value': function () {
+      var format = module['format-options'] || {};
+      var matcher = format.type === 'duration' ? config.durationRegex : config.valueRegex;
       return browser
         .$('#' + module.slug + ' .impact-number strong')
           .text()
-            .should.eventually.match(config.valueRegex);
+            .should.eventually.match(matcher);
 
     },
     'has period output': function () {


### PR DESCRIPTION
We need to use a different regex when modules are shown with a duration format to when they're a simple number.
