### PR TITLE
Swap stack tests out for line tests

### DIFF
--- a/lib/tests/modules/availability.js
+++ b/lib/tests/modules/availability.js
@@ -11,7 +11,7 @@ module.exports = function (browser, module, suite /*, config*/) {
             .should.eventually.match(/^([0-9\.]+s)|(\(no data\))$/);
 
     },
-    'has a page load time graph': require('./graph/components').stack(browser, '#' + module.slug + ' .response-time-graph'),
+    'has a page load time graph': require('./graph/components').line(browser, '#' + module.slug + ' .response-time-graph'),
     'has an uptime time numerical output': function () {
       return browser
         .$('#' + module.slug + ' .impact-number.uptime strong')
@@ -19,7 +19,7 @@ module.exports = function (browser, module, suite /*, config*/) {
             .should.eventually.match(/^[0-9\.]+%$/);
 
     },
-    'has an uptime time graph': require('./graph/components').stack(browser, '#' + module.slug + ' .uptime-graph')
+    'has an uptime time graph': require('./graph/components').line(browser, '#' + module.slug + ' .uptime-graph')
   };
 
   _.each(tests, function (test, key) {

--- a/lib/tests/modules/completion/graph.js
+++ b/lib/tests/modules/completion/graph.js
@@ -4,7 +4,7 @@ var Mocha = require('mocha'),
 module.exports = function (browser, module, suite /*, config*/) {
 
   var tests = {
-    'has a stack and a line': require('../graph/components').stack(browser, '#' + module.slug)
+    'has a line': require('../graph/components').line(browser, '#' + module.slug)
   };
 
   _.each(tests, function (test, key) {

--- a/lib/tests/modules/graph/components.js
+++ b/lib/tests/modules/graph/components.js
@@ -2,6 +2,15 @@ var _ = require('underscore');
 
 module.exports = {
 
+  line: function (browser, selector, index) {
+    var lineInGroup = _.isNumber(index) ? '.group' + index : '';
+    return function () {
+      return browser
+        .$(selector + ' svg .line' + lineInGroup)
+          .should.eventually.exist;
+    };
+  },
+
   stack: function (browser, selector, index) {
     var lineInGroup = _.isNumber(index) ? '.group' + index : '';
     return function () {


### PR DESCRIPTION
For modules that have been updated to no longer contain a stack, just test for a line instead.
