### PR TITLE
Fix tests for content dashboard titles

### DIFF
--- a/lib/tests/dashboard.js
+++ b/lib/tests/dashboard.js
@@ -30,12 +30,13 @@ module.exports = function (browser, dashboard, suite, config) {
     exists: function exists() {
       return browser
         .title()
-          .should.become(dashboard.strapline + ' - ' + dashboard.title + ' - GOV.UK')
+          .should.eventually.contain(dashboard.strapline + ' - ' + dashboard.title)
         .$('h1').text()
-          .should.eventually.equal(dashboard.strapline + '\n' + dashboard.title)
+          .should.eventually.contain(dashboard.strapline + '\n' + dashboard.title)
         .$('body.ready')
           .should.eventually.exist;
     }
+
   };
 
   _.each(tests, function (test, key) {


### PR DESCRIPTION
Content dashboards have ":web traffic" auto appended to their title, so no longer match the old tested values.
