### PR TITLE
We've removed support for SSLV3 because of POODLE

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -22,7 +22,7 @@ var driver = {
           }, function (err, processes) {
             if (!processes.length) {
               process.stdout.write('No webdriver instance found on port ' + config.port + '. Starting phantomjs...');
-              webdriverProcess = cp.spawn(phantomPath, ['--webdriver', config.port], {
+              webdriverProcess = cp.spawn(phantomPath, ['--webdriver', config.port, '--ssl-protocol', 'tlsv1'], {
                 stdio: 'ignore'
               });
             } else {


### PR DESCRIPTION
We need to update phantom to use the ssl protocol tlsv1.

Once phantom sets this as the default protocol we can remove this again.

![](http://media.giphy.com/media/H7VnDkXDsuowM/giphy.gif)
