### PR TITLE
This config is still required for standalone mode.

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,5 +16,6 @@
     "port": 7070,
     "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}"
   },
-  "unpublished": false
+  "unpublished": false,
+  "path": "../spotlight"
 }


### PR DESCRIPTION
This was removed in a previous refactor. It's needed for standalone mode.
