### PR TITLE
Add a guard clause for svg attribute presence

### DIFF
--- a/lib/tests/modules/graph/components.js
+++ b/lib/tests/modules/graph/components.js
@@ -19,14 +19,18 @@ module.exports = {
         .$(selector + ' svg .line' + lineInGroup)
           .should.eventually.exist
           .getAttribute('d').then(function (d) {
-            linePath = d.split('M')[1];
+            if (d !== null) {
+              linePath = d.split('M')[1];
+            }
           })
         .$(selector + ' svg .stack' + lineInGroup)
           .should.eventually.exist
           .getAttribute('d').then(function (d) {
             // the line follows the top of the stack, so the line path should be a
             // substring of the stack path
-            d.should.contain(linePath);
+            if (d !== null) {
+              d.should.contain(linePath);
+            }
           });
     };
   }


### PR DESCRIPTION
This is failing for some dashboards as [`getAttribute('d')`](https://github.com/alphagov/cheapseats/compare/fix-tests?expand=1#diff-8818dd2f06c58f4fe3830a361f3551ccR21) returns null
so calls to `.split()` and `.should()` subsequently fail.