### PR TITLE
Downgrade node version to 6.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/alphagov/cheapseats.git"
   },
   "engines": {
-    "node": "6.11.3"
+    "node": "6.11.2"
   },
   "bin": "./cheapseats",
   "private": true,


### PR DESCRIPTION
Downgrade node to match common GOV.UK node runtime.