### PR TITLE
Change cheapseats config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 tmp
+dashboards

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "stubGlob": "*.json",
   "port": 5555,
   "downloadFolder": "./dashboards/",
-  "dashboardsUrl": "https://stagecraft.production.performance.service.gov.uk/public/dashboards",
+  "dashboardsUrl": "https://performance-platform-stagecraft-staging.cloudapps.digital/public/dashboards",
   "dashboardSlugs": [
     "student-finance-england-full-time-study-applications",
     "book-practical-driving-test",
@@ -22,7 +22,7 @@
   "browserHeight": 800,
   "serverConfig": {
     "port": 7070,
-    "backdropUrl": "https://www.performance.service.gov.uk/data/{{ data-group }}/{{ data-type }}"
+    "backdropUrl": "https://performance-platform-backdrop-read-staging.cloudapps.digital/data/{{ data-group }}/{{ data-type }}"
   },
   "unpublished": false,
   "path": "../spotlight"

--- a/lib/spotlight.js
+++ b/lib/spotlight.js
@@ -58,13 +58,13 @@ function getDashboardsList(config, callback) {
   }
 }
 
-function downloadSingleDashboard (dashboardList, count, path, deferred) {
+function downloadSingleDashboard (dashboardsUrl, dashboardList, count, path, deferred) {
   var slug = dashboardList[count],
     total = dashboardList.length;
 
   console.info('Downloading dashboard for:', slug);
   request({
-      url: 'https://stagecraft.production.performance.service.gov.uk/public/dashboards?slug=' + slug,
+      url: dashboardsUrl + '?slug=' + slug,
       maxAttempts: 5,
       retryDelay: 1000,
       retryStrategy: retryStrategy, // (default) retry on 5xx or network errors
@@ -81,7 +81,7 @@ function downloadSingleDashboard (dashboardList, count, path, deferred) {
       if (count === total) {
         deferred.resolve();
       } else {
-        downloadSingleDashboard(dashboardList, count, path, deferred);
+        downloadSingleDashboard(dashboardsUrl, dashboardList, count, path, deferred);
       }
     }).pipe(
     fs.createWriteStream(path + slug + '.json')
@@ -100,7 +100,7 @@ function downloadDashboards (dashboardList, config) {
   rimraf(config.downloadFolder, function () {
     fs.mkdir(config.downloadFolder, function () {
       var count = 0;
-      downloadSingleDashboard(dashboardList, count, config.downloadFolder, deferred)
+      downloadSingleDashboard(config.dashboardsUrl, dashboardList, count, config.downloadFolder, deferred)
         .then(function () {
           deferred.resolve();
         });


### PR DESCRIPTION
Cheapseats was looking at the old apps on the old infrastructure to run its tests. Once the old stagecraft was turned off, all of our travis tests for spotlight started failing.

![image](https://user-images.githubusercontent.com/2454380/32846058-371ec0ae-ca1e-11e7-9a12-65acf5dc57a4.png)

This PR should fix the tests.