### PR TITLE
Quick corrections to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 tmp
-dashboards
+/dashboards/

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "stubGlob": "*.json",
   "port": 5555,
   "downloadFolder": "./dashboards/",
-  "dashboardsUrl": "https://performance-platform-stagecraft-staging.cloudapps.digital/public/dashboards",
+  "dashboardsUrl": "https://performance-platform-stagecraft-production.cloudapps.digital/public/dashboards",
   "dashboardSlugs": [
     "student-finance-england-full-time-study-applications",
     "book-practical-driving-test",


### PR DESCRIPTION
1. Ignoring `dashboards` was too inclusive. Now we are only ignoring root-level `/dashboards` directories
2. Staging stagecraft data is out of sync with production stagecraft data ([spotlight is using prod](https://github.com/alphagov/spotlight/blob/master/config/config.development.json#L6) in dev mode)